### PR TITLE
updated pricing page to be dynamic

### DIFF
--- a/src/app/(marketing)/pricing/page.tsx
+++ b/src/app/(marketing)/pricing/page.tsx
@@ -6,6 +6,9 @@ import { BgPattern } from "@/components/ui/Bgpattern";
 import { SignUpButton } from "@/components/marketing/pricing/LandingSignUp";
 import { CheckBoxIcon } from "@/res/icons/CheckBoxIcon";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export const metadata: Metadata = {
   title: "Pricing",
 };


### PR DESCRIPTION
# Description 📣

ISSUE: When using the [OSS buildpack](https://github.com/tierrun/tier-run-buildpack) on Heroku with this template, the app would fail to build.

Next.js utilizes Server-Side Rendering (SSR) to generate and serve pages.

The pricing page was static, so next.js would try and generate it while building the app, and would attempt to get the pricing data from the tier api.

Since the buildpack is installed AFTER the pages are built, the api was not available. 

This caused the pricing page to fail to build, and thus the app would fail as well.

The fix is to add dynamic to the page so that it doesn't pre build the page.

## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Tested successfully locally with and without the CLI -serve and on Heroku.

```javascript
export const dynamic = "force-dynamic";
export const revalidate = 0;
```

---

- [X] I have agreed and acknowledged the [code of conduct](https://github.com/tierrun/tier-vercel-openai/blob/main/CODE_OF_CONDUCT.md). 📝
